### PR TITLE
remove pinned versions from requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/DataResponsibly/DataSynthesizer',
-    version='0.1.2+iai.0.0.1',
+    version='0.1.2+iai.0.0.2',
     zip_safe=False,
 )


### PR DESCRIPTION
Removing pinned versions in requirements to resolve conflicts with campfire.